### PR TITLE
Fix the correct ping target as HTTP:8080/health

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -524,6 +524,7 @@ The default persistent disk value is 50 GB. Pivotal recommends increasing this v
 1. On the **Configure Health Check** page, enter the following values:
   * **Ping Protocol**: Select **HTTP**.
   * **Ping Port**: Set to `8080`. 
+  * **Ping Path**: Set to `\health`. 
   * **Interval**: Set to `5` seconds. 
   * **Response Timeout**: Set to `3` seconds.
   * **Unhealthy threshold**: Set to `3`.


### PR DESCRIPTION
The installation guide does not specify the correct ping path, /health.  If set differently or not set, the router will be out of service for the Web ELB, and the SRT/ERT installation will fail.